### PR TITLE
update cumulative dataset filename to 2024

### DIFF
--- a/data-raw/create_dataverse-ids.R
+++ b/data-raw/create_dataverse-ids.R
@@ -2,7 +2,7 @@ library(tibble)
 
 cces_dv_ids <- tribble(
   ~cces_name, ~year, ~doi, ~filename,  ~caseid_var, ~server,
-  "cumulative", NA,   "10.7910/DVN/II2DB6", "cumulative_2006-2023.dta", "case_id", "dataverse.harvard.edu",
+  "cumulative", NA,   "10.7910/DVN/II2DB6", "cumulative_2006-2024.dta", "case_id", "dataverse.harvard.edu",
   "2006",       2006, "10.7910/DVN/Q8HC9N", "cces_2006_common.tab", "v1000",   "dataverse.harvard.edu",
   "2007",       2007, "10.7910/DVN/OOXTJ5", "CCES07_OUTPUT.sav", "caseid",  "dataverse.harvard.edu",
   "2008",       2008, "10.7910/DVN/YUYIVB", "cces_2008_common.tab", "V100",    "dataverse.harvard.edu",


### PR DESCRIPTION
Hi there, greatly appreciate this package. The following line in the demo vignette currently doesn't work:

```R
ccc <- get_cces_dataverse("cumulative")
```

because the filename for the [`10.7910/DVN/II2DB6`](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/II2DB6) cumulative dataset has changed.

As far as I can tell this is all that would need to be changed. Happy to make any other modifications necessary. 