### PR TITLE
Fix issue #29

### DIFF
--- a/R/district-coding.R
+++ b/R/district-coding.R
@@ -33,14 +33,15 @@ to_cd <- function(state, num) {
     state <- recode(as.numeric(state), !!!fips_to_st)
   }
 
-  statenames = ccesMRPprep::states_key$state
+  statenames = c(ccesMRPprep::states_key$state, "District of Columbia", "DC")
   if (all(state %in% c(statenames, toupper(statenames), tolower(statenames)))) {
     state_to_st <- deframe(transmute(states_key, state = toupper(.data$state), st = .data$st))
+    state_to_st["DISTRICT OF COLUMBIA"] <- "DC"
     state <- recode(toupper(state), !!!state_to_st)
   }
 
   if (is.character(num)) {
-    num <- replace(num, num == "AL", "01")
+    num <- replace(num, num %in% c("AL", "DC"), "01")
     num <- as.numeric(num)
   }
 
@@ -48,5 +49,5 @@ to_cd <- function(state, num) {
   num <- replace(num, num == 0, "01") # at large becomes one
   numchr  <- str_pad(num, width = 2, pad = "0")
 
-  as.character(glue("{state}-{numchr}"))
+  replace(as.character(glue("{state}-{numchr}")), state == "DC", NA_character_)
 }

--- a/R/district-coding.R
+++ b/R/district-coding.R
@@ -41,7 +41,7 @@ to_cd <- function(state, num) {
   }
 
   if (is.character(num)) {
-    num <- replace(num, num %in% c("AL", "DC"), "01")
+    num <- replace(num, num == "AL", "01")
     num <- as.numeric(num)
   }
 

--- a/vignettes/overview.Rmd
+++ b/vignettes/overview.Rmd
@@ -63,7 +63,7 @@ A prior could be specified here as well, but this is not strictly necessary and 
 
 We provide wrappers around the great [tidycensus](https://walker-data.com/tidycensus/) package that produces ACS data and post-stratification tables from the ACS. Tailored lookup tables internally will pull out the appropriate CD-level counts and label them so that they match up with CCES keys. District-level information, which is not necessary ACS data (e.g. election outcomes) must be supplied here as well. 
 
-```{r}
+```{r, eval = FALSE}
 # only do this once, replacing the input with your census key
 tidycensus::census_api_key(Sys.getenv("CENSUS_API_KEY"))
 


### PR DESCRIPTION
Reprex of issue:
``` r
library(ccesMRPprep)
to_cd(c("Alabama", "Alaska"), c("5", "AL"))
#> [1] "AL-05" "AK-01"
to_cd(c("Alabama", "Alaska", "District of Columbia"), c("5", "AL", "AL"))
#> [1] "Alabama-05"              "Alaska-01"              
#> [3] "District of Columbia-01"
```

<sup>Created on 2026-06-26 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

Fix:
https://github.com/kuriwaki/ccesMRPprep/blob/8923abb0c82f58f6786ce41694748f6f32153c7a/R/district-coding.R#L36-L52

Reprex after fix:
``` r
library(ccesMRPprep)
to_cd(c("Alabama", "Alaska"), c("5", "AL"))
#> [1] "AL-05" "AK-01"
to_cd(c("Alabama", "Alaska", "District of Columbia"), c("5", "AL", "AL"))
#> [1] "AL-05" "AK-01" NA
```

<sup>Created on 2026-06-26 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>